### PR TITLE
Fix missing includes in mathf

### DIFF
--- a/sixit/dmath/mathf/__rem_pio2_large.h
+++ b/sixit/dmath/mathf/__rem_pio2_large.h
@@ -129,7 +129,10 @@ Contributors: Sherry Ignatchenko, Serhii Iliukhin
 #ifndef sixit_dmath_math_operations___rem_pio2_large_h_included
 #define sixit_dmath_math_operations___rem_pio2_large_h_included
 
+#include "floor.h"
 #include "__utils.h"
+
+#include <cassert>
 
 namespace sixit::dmath::mathf
 {

--- a/sixit/dmath/mathf/acos.h
+++ b/sixit/dmath/mathf/acos.h
@@ -16,6 +16,7 @@ Contributors: Sherry Ignatchenko, Serhii Iliukhin
 #ifndef sixit_dmath_math_operations_acos_h_included
 #define sixit_dmath_math_operations_acos_h_included
 
+#include "sqrt.h"
 #include "__utils.h"
 
 namespace sixit::dmath::mathf

--- a/sixit/dmath/mathf/isfinite.h
+++ b/sixit/dmath/mathf/isfinite.h
@@ -6,6 +6,8 @@ Contributors: Sherry Ignatchenko, Serhii Iliukhin
 #ifndef sixit_dmath_math_operations_isfinite_h_included
 #define sixit_dmath_math_operations_isfinite_h_included
 
+#include <sixit/dmath/traits.h>
+
 namespace sixit::dmath::mathf
 {
     template <typename fp>

--- a/sixit/dmath/mathf/log.h
+++ b/sixit/dmath/mathf/log.h
@@ -12,6 +12,11 @@ Contributors: Sherry Ignatchenko, Serhii Iliukhin
 #ifndef sixit_dmath_math_operations_log_h_included
 #define sixit_dmath_math_operations_log_h_included
 
+#include <sixit/dmath/traits.h>
+#include "__utils.h"
+
+#include <cmath>
+
 namespace sixit::dmath::mathf
 {
     template <typename fp>   

--- a/sixit/dmath/mathf/log10.h
+++ b/sixit/dmath/mathf/log10.h
@@ -19,6 +19,10 @@ Contributors: Sherry Ignatchenko, Serhii Iliukhin
 #ifndef sixit_dmath_math_operations_log10_h_included
 #define sixit_dmath_math_operations_log10_h_included
 
+#include <sixit/dmath/traits.h>
+
+#include <cmath>
+
 namespace sixit::dmath::mathf
 {
     template <typename fp>


### PR DESCRIPTION
Some header file were not self-contained.
I tried to match the includes style, let me know.
Some of these only comes up during instantiation so I would presume there could be more.